### PR TITLE
Modify elscreen-kill-others

### DIFF
--- a/elscreen.el
+++ b/elscreen.el
@@ -944,6 +944,10 @@ is ommitted, current screen will survive."
      ((or
        (not (called-interactively-p 'any))
        (yes-or-no-p (format "Really kill screens other than %d? " screen)))
+      (when (= screen (elscreen-get-current-screen))
+        (elscreen-set-window-configuration
+         (elscreen-get-current-screen)
+         (elscreen-current-window-configuration)))
       (setq screen-list-string (mapconcat
                                 (lambda (screen)
                                   (elscreen-kill-internal screen)


### PR DESCRIPTION
When elscreen-kill-others is called from helm-M-x, a window-configuration has been saved
by elscreen-run-screen-update-hook invoked by change-major-mode-hook and post-command-hook.
Then elscreen-kill-others uses the window-configuration which has the window helm-M-x made.
Sometimes a similar situation occurs when elscreen-kill-others is called in other ways.

So elscreen-kill-others was changed like elscreen-goto.

helmから呼ぶと，helmが作ったウィンドウが残ってしまうため，elscreen-gotoを模倣して修正しました．

よろしくお願いします．