### PR TITLE
Modify elscreen-swap

### DIFF
--- a/elscreen.el
+++ b/elscreen.el
@@ -1031,6 +1031,9 @@ is ommitted, current screen will survive."
    ((elscreen-one-screen-p)
     (elscreen-message "There is only one screen, cannot swap"))
    (t
+    (elscreen-set-window-configuration
+     (elscreen-get-current-screen)
+     (elscreen-current-window-configuration))
     (let* ((current-screen (elscreen-get-current-screen))
            (previous-screen (elscreen-get-previous-screen))
            (current-screen-property


### PR DESCRIPTION
When elscreen-swap is called from helm-M-x, a window-configuration has been saved
by elscreen-run-screen-update-hook invoked by change-major-mode-hook and post-command-hook.
Then elscreen-swap sets the window-configuration which has the window helm-M-x made
as the other screen.
Sometimes a similar situation occurs when elscreen-swap is called in other ways.

So elscreen-swap was changed like elscreen-goto.

先程 pull request した elscreen-kill-others と同じ問題の修正です．

よろしくお願いします．