### PR TITLE
Show second menu item separator

### DIFF
--- a/elscreen.el
+++ b/elscreen.el
@@ -1359,7 +1359,7 @@ Use \\[toggle-read-only] to permit editing."
               "Toggle Screen"
               'elscreen-toggle
               :help "Toggle to the screen selected previously")
-        (list 'elscreen-command-separator
+        (list 'elscreen-command-separator-toggle
               'menu-item
               "--")
         (list 'elscreen-toggle-display-screen-number


### PR DESCRIPTION
メニューの "Display Screen Number" の上のセパレータが表示されていないことに対する修正です。
