### PR TITLE
Fix the bug of mode line described in README

### DIFF
--- a/elscreen.el
+++ b/elscreen.el
@@ -1294,17 +1294,14 @@ Use \\[toggle-read-only] to permit editing."
 
 ;;; Mode Line & Menu & Tab
 
-;; GNU Emacs
-(defvar elscreen-mode-line-string "[0]")
 (defun elscreen-mode-line-update ()
   (when (elscreen-screen-modified-p 'elscreen-mode-line-update)
-    (setq elscreen-mode-line-string
-          (format "[%d]" (elscreen-get-current-screen)))
     (force-mode-line-update)))
 
 (let ((point (memq 'mode-line-position mode-line-format))
-      (elscreen-mode-line-elm '(elscreen-display-screen-number
-                                (" " elscreen-mode-line-string))))
+      (elscreen-mode-line-elm
+       '(elscreen-display-screen-number
+         (:eval (format " [%d]" (elscreen-get-current-screen))))))
   (when (null (member elscreen-mode-line-elm mode-line-format))
     (setcdr point (cons elscreen-mode-line-elm (cdr point)))))
 


### PR DESCRIPTION
README に書かれているモードラインのバグに対する修正です。

バグの再現手順は以下の通りです。
1. Emacs を -Q オプションで起動
2. `elscreen-start`
3. `make-frame`
4. 新しいフレームで `C-z C-c` してスクリーンを作成

ここで新しいフレームのモードラインは `[1]` で古いフレームのモードラインは `[0]` となっていますが、マウスのクリックなどでフレームを切り替えると 2 つのフレームのモードラインが同時に同じ値に更新されます。
